### PR TITLE
Ensure empty string for description in storePost method

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -872,7 +872,7 @@ class PostController extends Controller
         );
 
         $post->update([
-            'description' => $request->input('description', $post->description),
+            'description' => $request->description ?? '',
             'images' => $finalImages,
         ]);
 
@@ -898,7 +898,7 @@ class PostController extends Controller
 
         $post = Post::create([
             'user_id' => Auth::id(),
-            'description' => $request->description,
+            'description' => $request->description ?? '',
             'images' => $imagesArray,
         ]);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated post editing so a missing description now saves as empty instead of keeping the previous text.
  * This makes description updates behave more consistently when the field is left blank.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->