### PR TITLE
fix: prevent role privilege escalation via profile and bulk-update en…

### DIFF
--- a/app/Http/Controllers/API/TrainingController.php
+++ b/app/Http/Controllers/API/TrainingController.php
@@ -393,11 +393,21 @@ class TrainingController extends Controller
             return $checkResult;
         }
 
+        // SECURITY: this route is only guarded by auth:sanctum, so authorization must be
+        // enforced here. Only privileged actors may change roles — otherwise any
+        // authenticated user enrolled in a training can promote themselves to admin.
+        $actor = $request->user();
+        $actorRoles = is_array($actor->role) ? $actor->role : array_filter([(string) $actor->role]);
+        $canManageRoles = ! empty(array_intersect(
+            array_map('strtolower', $actorRoles),
+            ['admin', 'super_admin', 'moderateur', 'coach']
+        ));
+
         $validated = $request->validate([
             'user_ids' => 'required|array|min:1',
             'user_ids.*' => 'required|exists:users,id',
             'roles' => 'nullable|array',
-            'roles.*' => 'nullable|string',
+            'roles.*' => 'nullable|string|in:student,coach,admin,super_admin,moderateur,studio_responsable,responsable_studio,coworker,pro,recruiter',
             'status' => 'nullable|string|in:Working,Studying,Internship,Unemployed,Freelancing',
         ]);
 
@@ -417,7 +427,7 @@ class TrainingController extends Controller
         foreach ($users as $user) {
             $updateData = [];
 
-            if ($request->has('roles') && !empty($validated['roles'])) {
+            if ($request->has('roles') && !empty($validated['roles']) && $canManageRoles) {
                 $updateData['role'] = array_values(array_map(function ($r) {
                     return strtolower((string) $r);
                 }, array_filter($validated['roles'])));

--- a/app/Http/Controllers/FormationController.php
+++ b/app/Http/Controllers/FormationController.php
@@ -468,7 +468,7 @@ class FormationController extends Controller
             'user_ids' => 'required|array|min:1',
             'user_ids.*' => 'required|exists:users,id',
             'roles' => 'nullable|array',
-            'roles.*' => 'nullable|string',
+            'roles.*' => 'nullable|string|in:student,coach,admin,super_admin,moderateur,studio_responsable,responsable_studio,coworker,pro,recruiter',
             'status' => 'nullable|string|in:Working,Studying,Internship,Unemployed,Freelancing,Certified',
         ]);
 

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -1026,7 +1026,7 @@ class UsersController extends Controller
             'name' => 'nullable|string',
             'email' => 'nullable|email|unique:users,email,' . $user->id,
             'roles' => 'nullable|array',
-            'roles.*' => 'string',
+            'roles.*' => 'string|in:student,coach,admin,super_admin,moderateur,studio_responsable,responsable_studio,coworker,pro,recruiter',
             'status' => 'nullable|string',
             'formation_id' => 'nullable|integer|exists:formations,id',
             'phone' => 'nullable|string',
@@ -1069,15 +1069,19 @@ class UsersController extends Controller
             $validated['resume'] = $user->storeResumeFromUpload($request->file('resume'));
         }
 
-        // Map roles (array) to 'role' JSON column, lowercased
-        if ($request->has('roles')) {
+        // Map roles (array) to 'role' JSON column, lowercased.
+        // SECURITY: only privileged actors may change roles. A self-updating student
+        // must never be able to escalate their own role. Without this gate the endpoint
+        // is a broken-access-control / mass-assignment privilege escalation (a student
+        // can POST roles[]=admin to /students/update/{their-own-id} and become admin).
+        unset($validated['roles'], $validated['role']);
+        if ($request->has('roles') && $canEditOthers) {
             $roles = $request->input('roles');
             if (is_array($roles)) {
                 $validated['role'] = array_values(array_map(function ($r) {
                     return strtolower((string) $r);
                 }, $roles));
             }
-            unset($validated['roles']);
         }
 
         $isSelfUpdate = (int) $actor->id === (int) $user->id;


### PR DESCRIPTION
…dpoints

Two Broken Access Control (OWASP A01) paths let a non-privileged user set their own `role`, escalating to admin:

- PUT /students/update/{user} (UsersController@update): a student editing their own profile passed the ownership gate, and the roles->role write had no authorization check. Now the role write is gated behind $canEditOthers, so a self-updating student can no longer change their role.

- POST /api/trainings/{id}/bulk-update-users (API TrainingController@ bulkUpdateUsers): guarded only by auth:sanctum with no role check, so any authenticated user enrolled in a training could promote themselves. Now the role write is gated behind a privileged-actor check.

Defense in depth: constrain roles.* validation to a known allow-list in all three bulk/profile role writes (UsersController, API TrainingController, FormationController) so arbitrary role strings are rejected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened role-management security by limiting role assignments to supported values.
  * Prevented unauthorized users from changing their own roles or assigning roles to others.
  * Preserved independent status updates when role changes are not permitted.
  * Continued normalizing role values to lowercase for consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->